### PR TITLE
Replace one function with index expression

### DIFF
--- a/aws_config.tf
+++ b/aws_config.tf
@@ -80,15 +80,15 @@ data "aws_iam_policy_document" "aws_config" {
 
   statement {
     actions   = ["sns:*"]
-    resources = [one(aws_sns_topic.aws_config_updates_topic).arn]
+    resources = [aws_sns_topic.aws_config_updates_topic[0].arn]
   }
 
   statement {
     actions = ["s3:*"]
 
     resources = [
-      one(aws_s3_bucket.aws_config_configuration_bucket).arn,
-      "${one(aws_s3_bucket.aws_config_configuration_bucket).arn}/*"
+      aws_s3_bucket.aws_config_configuration_bucket[0].arn,
+      "${aws_s3_bucket.aws_config_configuration_bucket[0].arn}/*"
     ]
   }
 }
@@ -97,7 +97,7 @@ resource "aws_iam_role_policy" "aws_config_iam_policy" {
   count  = var.enable_aws_config ? 1 : 0
   name   = "terraform-awsconfig-policy"
   role   = aws_iam_role.aws_config_iam_role[0].id
-  policy = one(data.aws_iam_policy_document.aws_config).json
+  policy = data.aws_iam_policy_document.aws_config[0].json
 }
 
 resource "null_resource" "sns_subscribe" {

--- a/cloudtrail.tf
+++ b/cloudtrail.tf
@@ -14,7 +14,7 @@ resource "aws_cloudtrail" "cloudtrail" {
   name                          = var.trail_name
   s3_bucket_name                = var.cloudtrail_bucket != "" ? var.cloudtrail_bucket : local.bucket_name
   cloud_watch_logs_role_arn     = join("", aws_iam_role.cloudwatch_iam_role.*.arn)
-  cloud_watch_logs_group_arn    = length(aws_cloudwatch_log_group.log_group) == 1 ? "${one(aws_cloudwatch_log_group.log_group).arn}:*" : null
+  cloud_watch_logs_group_arn    = length(aws_cloudwatch_log_group.log_group) == 1 ? "${aws_cloudwatch_log_group.log_group[0].arn}:*" : null
   include_global_service_events = var.include_global_service_events
   enable_log_file_validation    = var.enable_log_file_validation
   is_multi_region_trail         = var.is_multi_region_trail
@@ -82,7 +82,7 @@ data "aws_iam_policy_document" "cloudwatch" {
 
   statement {
     actions   = ["logs:CreateLogStream", "logs:PutLogEvents"]
-    resources = ["${one(aws_cloudwatch_log_group.log_group).arn}:*"]
+    resources = ["${aws_cloudwatch_log_group.log_group[0].arn}:*"]
   }
 }
 
@@ -114,7 +114,7 @@ resource "aws_s3_bucket" "cloudtrail_bucket" {
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "cloudtrail_bucket" {
   count  = var.enable_cloudtrail && var.cloudtrail_bucket == "" ? 1 : 0
-  bucket = one(aws_s3_bucket.cloudtrail_bucket).bucket
+  bucket = aws_s3_bucket.cloudtrail_bucket[0].bucket
 
   rule {
     apply_server_side_encryption_by_default {
@@ -158,6 +158,6 @@ data "aws_iam_policy_document" "cloudtrail_bucket" {
 
 resource "aws_s3_bucket_policy" "cloudtrail_bucket" {
   count  = var.enable_cloudtrail && var.cloudtrail_bucket == "" ? 1 : 0
-  bucket = one(aws_s3_bucket.cloudtrail_bucket).bucket
+  bucket = aws_s3_bucket.cloudtrail_bucket[0].bucket
   policy = data.aws_iam_policy_document.cloudtrail_bucket.json
 }


### PR DESCRIPTION
## What

Replace the  one terraform function with index expression.
## Why

The one function works only with a minimum terraform version 0.15 in code [doc](https://developer.hashicorp.com/terraform/language/functions/one), some clients in Kabisa has an old terraform versions like 0.12.15 so when trying to upgrade terraform to 0.13.7 version, terraform complains and throw an error regarding using this function. 

## Code Review

Please consider the following checklist when reviewing this Pull Request.  
More background and details [here](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md).

* [ ] Does the code **actually solve** the problem it was meant to solve?
* [ ] Is the code covered by **unit tests**? **Integration tests**?
* [ ] Does anything here need **documentation**? (Focus on *why*, not *what.*)
* [ ] Does any of this code deal with **privacy sensitive information** or affects **security**? Ask an additional reviewer.
* [ ] Is the code easy to **understand** and **change** in the future?
* [ ] Is the same code or concept **duplicated**? Find a balance between DRYness and readability.
* [ ] Does the code reasonably adhere to the Kabisa [**coding standards**](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md)?
* [ ] Be kind.
