### PR TITLE
Feat/add S3 bucket and Dynamodb Tables

### DIFF
--- a/dynamodb.tf
+++ b/dynamodb.tf
@@ -1,6 +1,6 @@
 // Terraform State dynamodb table
 resource "aws_dynamodb_table" "kabisa_terraform_lockfiles_dynamodb_table" {
-  count = var.dynamodb_tables_creation ? 1 : 0
+  count          = var.dynamodb_tables_creation ? 1 : 0
   name           = var.dynamodb_tables_name
   read_capacity  = 5
   write_capacity = 5

--- a/dynamodb.tf
+++ b/dynamodb.tf
@@ -1,0 +1,17 @@
+// Terraform State dynamodb table
+resource "aws_dynamodb_table" "kabisa_terraform_lockfiles_dynamodb_table" {
+  count = var.dynamodb_tables_creation ? 1 : 0
+  name           = var.dynamodb_tables_name
+  read_capacity  = 5
+  write_capacity = 5
+  hash_key       = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = {
+    Terraform = true
+  }
+}

--- a/s3.tf
+++ b/s3.tf
@@ -9,7 +9,7 @@ resource "aws_s3_bucket" "kabisa_terraform_statefiles_bucket" {
 }
 
 resource "aws_s3_bucket_acl" "s3_bucket_private_acl" {
-  count  = var.s3_bucket_state_file_creation ? 1 : 0
+  count      = var.s3_bucket_state_file_creation ? 1 : 0
   bucket     = aws_s3_bucket.kabisa_terraform_statefiles_bucket[count.index].id
   acl        = "private"
   depends_on = [aws_s3_bucket_ownership_controls.s3_bucket_acl_ownership]

--- a/s3.tf
+++ b/s3.tf
@@ -1,0 +1,42 @@
+// Terraform State S3 buacket  
+resource "aws_s3_bucket" "kabisa_terraform_statefiles_bucket" {
+  count  = var.s3_bucket_state_file_creation ? 1 : 0
+  bucket = var.s3_bucket_state_file_name
+
+  tags = {
+    Terraform = true
+  }
+}
+
+resource "aws_s3_bucket_acl" "s3_bucket_private_acl" {
+  count  = var.s3_bucket_state_file_creation ? 1 : 0
+  bucket     = aws_s3_bucket.kabisa_terraform_statefiles_bucket[count.index].id
+  acl        = "private"
+  depends_on = [aws_s3_bucket_ownership_controls.s3_bucket_acl_ownership]
+}
+
+resource "aws_s3_bucket_ownership_controls" "s3_bucket_acl_ownership" {
+  count  = var.s3_bucket_state_file_creation ? 1 : 0
+  bucket = aws_s3_bucket.kabisa_terraform_statefiles_bucket[count.index].id
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "versioning_bucket" {
+  count  = var.s3_bucket_state_file_creation ? 1 : 0
+  bucket = aws_s3_bucket.kabisa_terraform_statefiles_bucket[count.index].id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "s3_bucket_encrypt_rule" {
+  count  = var.s3_bucket_state_file_creation ? 1 : 0
+  bucket = aws_s3_bucket.kabisa_terraform_statefiles_bucket[count.index].id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -224,26 +224,26 @@ variable "cloudwatch_encryption_enabled" {
 }
 
 variable "s3_bucket_state_file_creation" {
-  type = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Whether to create S3 bucket in the AWS Account to store terraform state file"
 }
 
 variable "s3_bucket_state_file_name" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "The S3 bucket name which store the terraform state file"
 }
 
 variable "dynamodb_tables_creation" {
-  type = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Whether to create dynamodb tables for terraform state file"
 }
 
 variable "dynamodb_tables_name" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "The dynamodb tables name"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -223,3 +223,27 @@ variable "cloudwatch_encryption_enabled" {
   description = "(Optional) Encrypt log data."
 }
 
+variable "s3_bucket_state_file_creation" {
+  type = bool
+  default = false
+  description = "Whether to create S3 bucket in the AWS Account to store terraform state file"
+}
+
+variable "s3_bucket_state_file_name" {
+  type = string
+  default = ""
+  description = "The S3 bucket name which store the terraform state file"
+}
+
+variable "dynamodb_tables_creation" {
+  type = bool
+  default = false
+  description = "Whether to create dynamodb tables for terraform state file"
+}
+
+variable "dynamodb_tables_name" {
+  type = string
+  default = ""
+  description = "The dynamodb tables name"
+}
+


### PR DESCRIPTION
## What

This PR is to add **`S3bucket`** and **`dynamoDB tables`** to module; thus when bootstrapping a new AWS Account in Kabisa; **`S3 bucket`** and **`DynamoDB tables`** will be provided as well, further new version of the module would be released accordingly!

## Why

We are providing S3 Bucket and DynamoDB tables to store the **`Terraform State File inside the AWS Account itself!`**

## Code Review

Please consider the following checklist when reviewing this Pull Request.  
More background and details [here](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md).

* [ ] Does the code **actually solve** the problem it was meant to solve?
* [ ] Is the code covered by **unit tests**? **Integration tests**?
* [ ] Does anything here need **documentation**? (Focus on *why*, not *what.*)
* [ ] Does any of this code deal with **privacy sensitive information** or affects **security**? Ask an additional reviewer.
* [ ] Is the code easy to **understand** and **change** in the future?
* [ ] Is the same code or concept **duplicated**? Find a balance between DRYness and readability.
* [ ] Does the code reasonably adhere to the Kabisa [**coding standards**](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md)?
* [ ] Be kind.
